### PR TITLE
Update README with wiki list of ontology efforts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
-# ontology
-Repository for a collaborative effort towards a standard ontology relevant for materials databases
+# Ontology
+
+Repository for a collaborative effort towards a standard ontology relevant for materials databases.
+
+## Information
+
+We are collecting a list of all ontology efforts relevant for our effort: [List of ontology efforts](https://github.com/Materials-Consortia/ontology/wiki/List-of-ontology-efforts).


### PR DESCRIPTION
Closes #6 

This updates the README, adding an "Information" section with a single sentence linking to the list of ontology efforts page in the wiki.